### PR TITLE
WEBOPS-974: add `space` to `systemd-journal` group

### DIFF
--- a/spacel-agent.yml
+++ b/spacel-agent.yml
@@ -46,6 +46,7 @@ plugins:
     username: space
     groups:
       - docker
+      - systemd-journal
     disable_modules:
       - byobu
       - landscape


### PR DESCRIPTION
Required for `journalctl` without `sudo`