### PR TITLE
WEBOPS-972: bundle cloudwatch-stats service

### DIFF
--- a/cloudwatch-stats.service
+++ b/cloudwatch-stats.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=cloudwatch-stats
+Wants=basic.target
+After=basic.target network.target
+
+[Service]
+User=nobody
+Group=nogroup
+ExecStart=/bin/sh -c "/usr/local/bin/mon-put-instance-stats.py --mem-util --disk-space-util --disk-path=/ ${DISK_PARAMS} ${ASG_PARAMS} --persistent"
+Restart=on-failure

--- a/spacel-agent.yml
+++ b/spacel-agent.yml
@@ -55,6 +55,7 @@ plugins:
     packages:
       - https://github.com/thepwagner/python-systemd/tarball/master#egg=python-systemd-0.1-planning-0
       - https://github.com/pebble/spacel-agent/tarball/master#egg=spacel-agent-0.0.1
+      - https://github.com/pebble/cloudwatch-mon-scripts-python/tarball/master#egg=cloudwatchmon-2.0.4
   file_copy:
     files:
       -
@@ -81,6 +82,11 @@ plugins:
         src: /app/manifests/developer.sh
         dst: /usr/local/bin/developer.sh
         permissions: "755"
+        owner: root
+      -
+        src: /app/manifests/cloudwatch-stats.service
+        dst: /etc/systemd/system/cloudwatch-stats.service
+        permissions: "644"
         owner: root
     mkdirs:
       -


### PR DESCRIPTION
This is installed, but not enabled by default (`spacel-agent` will do that).

There are two baked-in hooks for Systemd drop-ins that `spacel-agent` will write, like:

```
space@ip-10-200-2-49 ~ on master ✗ $ cat /etc/systemd/system/cloudwatch-stats.service.d/10-asg.conf
[Service]
Environment="ASG_PARAMS=--auto-scaling --auto-scaling-group=develop-laika-Asg-1N11B2LPV4WPK"
```