### PR TITLE
Customize docker.service

### DIFF
--- a/docker.service
+++ b/docker.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network.target docker.socket
+Requires=docker.socket
+
+[Service]
+Type=notify
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+ExecStart=/usr/bin/dockerd -H fd:// $DOCKER_OPTS
+ExecReload=/bin/kill -s HUP $MAINPID
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd 226 and above support this version.
+#TasksMax=infinity
+TimeoutStartSec=0
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/spacel-agent.yml
+++ b/spacel-agent.yml
@@ -88,6 +88,11 @@ plugins:
         dst: /etc/systemd/system/cloudwatch-stats.service
         permissions: "644"
         owner: root
+      -
+        src: /app/manifests/docker.service
+        dst: /lib/systemd/system/docker.service
+        permissions: "644"
+        owner: root
     mkdirs:
       -
         dir: /opt/spacel


### PR DESCRIPTION
The version baked into the .deb doesn't include `$DOCKER_OPTS`:
https://github.com/docker/docker/blob/b248de7e332b6e67b08a8981f68060e6ae629ccf/contrib/init/systemd/docker.service#L12

That's a CoreOS-ism that's pretty handy to have:
https://github.com/coreos/coreos-overlay/blob/3f76f6ce738da0d5a2d36b1cccb922c2ce0a72af/app-emulation/docker/files/docker.service-1.7#L12
So keep it.

Needed by the `SetupCloudWatchLogs` bits of https://github.com/pebble/spacel-agent/pull/42